### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Model Context Protocol server that provides SwitchBot device control capabilit
 
 [日本語](./README.ja.md)
 
+<a href="https://glama.ai/mcp/servers/k8m7mttrur"><img width="380" height="200" src="https://glama.ai/mcp/servers/k8m7mttrur/badge" alt="SwitchBot Server MCP server" /></a>
+
 ## Features
 
 - List devices


### PR DESCRIPTION
This PR adds a badge for the [SwitchBot MCP Server](https://glama.ai/mcp/servers/k8m7mttrur) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/k8m7mttrur"><img width="380" height="200" src="https://glama.ai/mcp/servers/k8m7mttrur/badge" alt="SwitchBot Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.