### PR TITLE
chore(deps): keep Node types on supported runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         dependency-type: production
       development-dependencies:
         dependency-type: development
+    ignore:
+      # Keep compiler types aligned with the minimum supported Node.js runtime.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
## Summary

- keep `@types/node` aligned with the minimum supported Node.js runtime
- ignore semver-major Dependabot version updates for `@types/node`
- continue allowing minor and patch updates within the current Node.js type major

## Rationale

The package supports Node.js 24.15 and newer. Type-checking against Node.js 26 definitions could permit APIs that are unavailable to supported Node.js 24 users, including in code paths that the cross-version runtime test matrix does not execute.

This follow-up prevents a repeat of Dependabot PR #9. The type major should move only when the minimum supported runtime moves.

## Verification

- parsed `.github/dependabot.yml` as YAML
- asserted the npm ignore rule targets only `@types/node`
- asserted the ignored update type is only `version-update:semver-major`
- `git diff --check`
