### PR TITLE
feat: harden MCP runtime and release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!package.json
+!package-lock.json
+!tsconfig.json
+!src/
+!src/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,14 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:45"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check formatting
         run: npm run format
       - name: Lint workflows
-        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+        run: npm run lint:actions
 
   test:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  packages: read
-  security-events: write
 
 concurrency:
   group: codeql-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +19,11 @@ concurrency:
 jobs:
   analyze:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,15 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run the complete repository check
-        run: npm run check
+        run: npm run check:ci
+      - name: Upload test evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scheduled-test-failure-node-${{ matrix.node }}
+          path: reports/junit.xml
+          if-no-files-found: ignore
+          retention-days: 3
 
   dependency-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,19 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
-  attestations: write
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -24,6 +23,8 @@ jobs:
           egress-policy: audit
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -32,40 +33,82 @@ jobs:
         run: npm install --global npm@11.19.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
-      - name: Verify source and package
-        run: npm run check
       - name: Verify release tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           PACKAGE_VERSION="$(node --input-type=module -e "import pkg from './package.json' with { type: 'json' }; process.stdout.write(pkg.version)")"
           if [[ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
             echo "Release tag $RELEASE_TAG does not match package version v$PACKAGE_VERSION." >&2
             exit 1
           fi
+      - name: Verify source and package
+        run: npm run check:ci
       - name: Pack release artifact
         id: pack
         run: |
-          npm pack --json > package-pack.json
+          mkdir release-package
+          npm pack --pack-destination release-package --json > package-pack.json
           PACKAGE_FILE="$(node --input-type=module -e "import fs from 'node:fs'; const result = JSON.parse(fs.readFileSync('package-pack.json', 'utf8')); process.stdout.write(result[0].filename)")"
           echo "file=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
-      - name: Attest release artifact
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: ${{ steps.pack.outputs.file }}
-      - name: Upload short-lived workflow artifact
+      - name: Upload exact release package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-package
-          path: ${{ steps.pack.outputs.file }}
+          path: release-package/${{ steps.pack.outputs.file }}
           if-no-files-found: error
-          retention-days: 7
-      - name: Attach package to GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          PACKAGE_FILE: ${{ steps.pack.outputs.file }}
-        run: gh release upload "$RELEASE_TAG" "$PACKAGE_FILE" --clobber
+          retention-days: 1
+      - name: Upload test evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-test-failure
+          path: reports/junit.xml
+          if-no-files-found: ignore
+          retention-days: 3
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+      - name: Use the repository npm version
+        run: npm install --global npm@11.19.0
+      - name: Download exact release package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8.0.0
+        with:
+          name: npm-package
+          path: release-package
+      - name: Resolve release package
+        id: package
+        run: |
+          mapfile -t PACKAGE_FILES < <(find release-package -maxdepth 1 -type f -name '*.tgz')
+          if [[ "${#PACKAGE_FILES[@]}" -ne 1 ]]; then
+            echo "Expected one package archive, found ${#PACKAGE_FILES[@]}." >&2
+            exit 1
+          fi
+          echo "file=${PACKAGE_FILES[0]}" >> "$GITHUB_OUTPUT"
+      - name: Attest release artifact
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ steps.package.outputs.file }}
       - name: Install pinned MCP Registry publisher
         env:
           MCP_PUBLISHER_VERSION: v1.8.0
@@ -76,6 +119,10 @@ jobs:
             --fail \
             --location \
             --proto '=https' \
+            --retry 3 \
+            --retry-all-errors \
+            --show-error \
+            --silent \
             --tlsv1.2 \
             --output "$ARCHIVE" \
             "https://github.com/modelcontextprotocol/registry/releases/download/$MCP_PUBLISHER_VERSION/mcp-publisher_linux_amd64.tar.gz"
@@ -84,9 +131,21 @@ jobs:
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Validate MCP Registry metadata
         run: mcp-publisher validate server.json
-      - name: Publish to npm with trusted publishing
-        run: npm publish "${{ steps.pack.outputs.file }}" --access public --provenance
-      - name: Authenticate to the MCP Registry
-        run: mcp-publisher login github-oidc
-      - name: Publish to the MCP Registry
-        run: mcp-publisher publish
+      - name: Publish or verify npm package
+        run: node scripts/release/publish-npm.mjs "${{ steps.package.outputs.file }}"
+      - name: Publish or verify MCP Registry metadata
+        run: node scripts/release/publish-registry.mjs
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_FILE: ${{ steps.package.outputs.file }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "$PACKAGE_FILE" --clobber
+          else
+            gh release create "$RELEASE_TAG" "$PACKAGE_FILE" \
+              --generate-notes \
+              --title "$RELEASE_TAG" \
+              --verify-tag
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,11 +9,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  security-events: write
 
 jobs:
   analysis:
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,16 @@ then enforces this via the pre-push guard.
 - `OpenSSF Scorecard`: reports repository supply-chain posture weekly.
 - `Scheduled verification`: catches dependency, runtime, container, and
   optionally read-only live API drift.
-- `Release`: verifies, packs, attests, attaches, and publishes a package after a
-  GitHub Release is published.
+- `Release`: verifies a version tag, publishes the exact attested package to npm
+  and the MCP Registry, then creates the GitHub Release.
 
-Actions are pinned to immutable commit SHAs. Dependabot updates npm dependencies
-and GitHub Actions weekly.
+Actions are pinned to immutable commit SHAs. Downloaded CI tools and container
+base images are checksum/digest pinned. Dependabot updates npm, GitHub Actions,
+and Docker dependencies weekly.
+
+The `@hono/node-server` override in `package.json` keeps the MCP Node adapter
+above the vulnerable range in GHSA-frvp-7c67-39w9. Remove it only after the
+upstream MCP package requires a patched release.
 
 ## Labels
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:24-alpine AS deps
+FROM node:24-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
@@ -11,7 +11,7 @@ COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
 
-FROM node:24-alpine AS runtime
+FROM node:24-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS runtime
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts

--- a/README.ja.md
+++ b/README.ja.md
@@ -51,11 +51,15 @@ code --add-mcp '{"name":"switchbot","command":"npx","args":["-y","@genm-dev/swit
 ## 概要
 
 - Node.js 24 LTS を基盤とする v3.0.0
+- MCP SDK v2とMCP 2026-07-28プロトコル交渉の明示的な検証
 - 標準 `fetch` と厳密な上流レスポンス検証
 - レイヤー分離（SwitchBotクライアント / MCPツール / トランスポート）
 - `stdio` と Streamable HTTP を正式サポート
 - HTTPモードは APIキー必須
+- HTTPデプロイ向けの同一ホストOrigin / Host検証
 - 全ツールで `structuredContent` を返却
+- MCPリスク注釈と読み取り専用SwitchBotリクエストの上限付きリトライ
+- シークレットをマスクするJSONL運用ログ
 - 対応ランタイム・配布パッケージ・コンテナを横断する公開repo向けCI
 
 ## 必要条件
@@ -81,8 +85,14 @@ npm install @genm-dev/switchbot-mcp
 - `MCP_TRANSPORT=stdio|http`（デフォルト: `stdio`）
 - `MCP_SERVER_API_KEY`（`http`時は必須）
 - `MCP_HTTP_HOST`（デフォルト: `127.0.0.1`）
+- `MCP_HTTP_ALLOWED_HOSTS`（任意: proxy / 公開ホスト名のカンマ区切り）
 - `MCP_HTTP_PORT`（デフォルト: `8787`）
 - `MCP_HTTP_PATH`（デフォルト: `/mcp`）
+
+`Origin` ヘッダーを持つHTTPリクエストは、`Host` と同じ許可リストの
+ホスト名を使う必要があります。localhostとbind hostは自動的に含まれます。
+リバースプロキシのホスト名は明示的に追加してください。不正なリクエストや
+cross-originリクエストは拒否されます。
 
 ### 実行オプション
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ code --add-mcp '{"name":"switchbot","command":"npx","args":["-y","@genm-dev/swit
 ## Highlights
 
 - v3.0.0 on the Node.js 24 LTS platform
+- MCP SDK v2 with explicit MCP 2026-07-28 protocol negotiation coverage
 - Native `fetch` with strict upstream response validation
 - Layered architecture (SwitchBot client / MCP tools / transports)
 - `stdio` and Streamable HTTP transports
 - API key required for HTTP transport
+- Same-host Origin and Host validation for HTTP deployments
 - Structured MCP tool outputs (`structuredContent`)
+- MCP risk annotations and bounded retries for read-only SwitchBot requests
+- Redacted JSONL operational logs
 - Public-repository CI across supported runtimes, package artifacts, and containers
 
 ## Requirements
@@ -81,8 +85,14 @@ npm install @genm-dev/switchbot-mcp
 - `MCP_TRANSPORT=stdio|http` (default: `stdio`)
 - `MCP_SERVER_API_KEY` (required for `http`)
 - `MCP_HTTP_HOST` (default: `127.0.0.1`)
+- `MCP_HTTP_ALLOWED_HOSTS` (optional comma-separated proxy/public hostnames)
 - `MCP_HTTP_PORT` (default: `8787`)
 - `MCP_HTTP_PATH` (default: `/mcp`)
+
+HTTP requests with an `Origin` header must use a hostname from the same
+allowlist as the `Host` header. Localhost and the configured bind host are
+included automatically. Add reverse-proxy hostnames explicitly; malformed or
+cross-origin requests are rejected.
 
 ### Runtime
 

--- a/docs/migration-v2-to-v3.md
+++ b/docs/migration-v2-to-v3.md
@@ -15,6 +15,14 @@ environment variable names are unchanged.
 - Device and scene identifiers are URL-encoded before requests are sent.
 - Malformed successful responses from the SwitchBot API now fail explicitly
   instead of being accepted through TypeScript-only assertions.
+- HTTP deployments validate both `Host` and browser `Origin` headers. Add
+  reverse-proxy or public hostnames to `MCP_HTTP_ALLOWED_HOSTS`.
+- Read-only upstream requests retry transient `429`, `502`, `503`, and `504`
+  responses at most twice within the original request timeout. Mutating
+  requests are never retried automatically.
+- Logs are emitted as redacted JSON Lines on stderr.
+- The MCP SDK v2 runtime supports both established 2025 clients and explicit
+  `2026-07-28` protocol negotiation.
 
 These checks intentionally fail closed. If an integration depended on malformed
 or undocumented upstream response shapes, update that integration rather than

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,25 +3,32 @@
 ## Versioning
 
 - SemVer is used.
-- Breaking changes require major version bump.
+- Breaking changes require a major version bump.
 
 ## Release path
 
 1. Merge a fully verified PR into `main`.
 2. Update `package.json` and `server.json` with the same intended SemVer version
    in a normal PR.
-3. Create and publish a GitHub Release tagged `v<package version>`.
-4. The `Release` workflow reruns the full repository check.
-5. The workflow packs and smoke-tests the exact npm artifact, creates a build
-   provenance attestation, attaches the tarball to the GitHub Release, and
-   publishes it to npm and the official MCP Registry.
+3. Create and push the annotated tag `v<package version>` from the intended
+   `main` commit.
+4. The `Release` workflow reruns the complete machine-readable repository check
+   and packs one exact npm tarball.
+5. The workflow attests that tarball, publishes or verifies it on npm, publishes
+   or verifies the matching official MCP Registry record, and only then creates
+   the GitHub Release with the tarball attached.
 
-## npm trusted publishing prerequisite
+Do not create the GitHub Release manually. Creating it last prevents a failed
+npm or Registry publication from appearing as a successful public release.
 
-Configure the npm package trusted publisher for:
+## Trusted publishing prerequisites
+
+Create a protected GitHub environment named `release`. Configure the npm
+package trusted publisher with:
 
 - repository: `genm/switchbot-mcp`;
 - workflow: `release.yml`;
+- environment: `release`;
 - package: `@genm-dev/switchbot-mcp`.
 
 The workflow uses GitHub OIDC and does not store a long-lived npm token. A
@@ -32,14 +39,22 @@ MCP Registry publication also uses GitHub OIDC. `package.json#mcpName`,
 `server.json#name`, and all package versions must match; the package smoke test
 enforces this before release.
 
+## Safe retries
+
+Rerunning the same tag is supported. The workflow compares the exact tarball
+SHA-512 integrity with npm before skipping an already-published package and
+compares the immutable Registry version with `server.json`. Any mismatch fails
+closed. The GitHub Release is created or updated only after both publications
+are verified.
+
 ## Rollback
 
-Published npm versions are immutable. Fix forward through a verified PR, bump
-the patch version, and publish a new GitHub Release. Deprecate an affected npm
-version when users must be warned.
+Published npm and MCP Registry versions are immutable. Fix forward through a
+verified PR, bump the patch version, and push a new version tag. Deprecate an
+affected npm version when users must be warned.
 
 ## Changelog discipline
 
 - Keep PR titles and commit messages clear and conventional.
 - Document user-visible behavior changes in release notes.
-- Confirm that the GitHub Release tag exactly matches `package.json`.
+- Confirm that the version tag exactly matches `package.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -18,8 +19,10 @@
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/node": "^24.13.3",
         "@vitest/coverage-v8": "^4.1.10",
+        "fast-check": "^4.9.0",
         "lefthook": "^2.1.10",
         "oxfmt": "^0.61.0",
         "oxlint": "^1.76.0",
@@ -912,44 +915,69 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
+        "hono": {
           "optional": true
-        },
-        "zod": {
-          "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2539,23 +2567,11 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2566,23 +2582,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2660,81 +2659,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2788,28 +2712,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/conventional-changelog-angular": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
@@ -2860,41 +2762,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
@@ -2944,6 +2811,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2952,32 +2820,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -2990,41 +2832,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -3046,42 +2859,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/es-toolkit": {
       "version": "1.50.0",
@@ -3147,12 +2930,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3163,19 +2940,11 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.2.tgz",
       "integrity": "sha512-YolzkJNxsTL3tCJMWFxpxtG2sCjbZ4LQUBUrkdaJK0ub0p6lmJt+2+1SwhKjLc652lpH9L/79Ptez972H9tphw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.0"
@@ -3188,6 +2957,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
       "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3203,78 +2973,41 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "pure-rand": "^8.0.0"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3305,45 +3038,6 @@
         }
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3357,15 +3051,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -3391,43 +3076,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/global-directory": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
@@ -3444,18 +3092,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3466,35 +3102,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/hono": {
       "version": "4.12.32",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
       "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3505,42 +3118,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3569,12 +3146,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/ini": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
@@ -3583,24 +3154,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
-      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
@@ -3623,16 +3176,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3688,6 +3236,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3734,13 +3283,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/lefthook": {
       "version": "2.1.10",
@@ -4223,61 +3767,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -4287,12 +3776,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -4313,36 +3796,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -4355,27 +3808,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/oxfmt": {
@@ -4518,32 +3950,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -4577,6 +3991,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -4611,19 +4026,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/publint": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.22.tgz",
@@ -4646,50 +4048,28 @@
         "url": "https://bjornlu.com/sponsor"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4739,22 +4119,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -4767,12 +4131,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -4787,61 +4145,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4854,81 +4162,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4954,15 +4191,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",
@@ -5071,15 +4299,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5105,37 +4324,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -5179,24 +4367,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/vite": {
       "version": "8.2.0",
@@ -5370,6 +4540,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5434,12 +4605,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5485,15 +4650,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:live": "vitest run tests/live/switchbot-live.test.ts",
     "test:watch": "vitest",
     "check": "npm run typecheck && npm run lint && npm run format && npm run test && npm run build && npm run lint:package && npm run smoke:package",
+    "check:ci": "npm run typecheck && npm run lint && npm run format && npm run test:ci && npm run build && npm run lint:package && npm run smoke:package",
     "lint": "oxlint .",
     "lint:package": "publint",
     "format": "oxfmt --check .",
@@ -54,19 +55,23 @@
     "hooks:install": "lefthook install",
     "smoke:container": "bash scripts/ci/verify-container.sh",
     "smoke:package": "node scripts/ci/verify-package.mjs",
+    "lint:actions": "bash scripts/ci/run-actionlint.sh",
     "commitlint": "commitlint --edit",
     "guard:rebase": "bash scripts/hooks/check-rebase-before-push.sh",
     "labels:sync": "bash scripts/github/sync-labels.sh"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.10",
+    "fast-check": "^4.9.0",
     "lefthook": "^2.1.10",
     "oxfmt": "^0.61.0",
     "oxlint": "^1.76.0",
@@ -74,6 +79,11 @@
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "@modelcontextprotocol/node": {
+      "@hono/node-server": "2.0.12"
+    }
   },
   "engines": {
     "node": ">=24.15.0",

--- a/scripts/ci/run-actionlint.sh
+++ b/scripts/ci/run-actionlint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly actionlint_version="1.7.12"
+readonly temporary_directory="$(mktemp -d)"
+readonly archive="${temporary_directory}/actionlint.tar.gz"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)
+    readonly platform="darwin_arm64"
+    readonly archive_sha256="aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
+    ;;
+  Darwin-x86_64)
+    readonly platform="darwin_amd64"
+    readonly archive_sha256="5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
+    ;;
+  Linux-aarch64 | Linux-arm64)
+    readonly platform="linux_arm64"
+    readonly archive_sha256="325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
+    ;;
+  Linux-x86_64)
+    readonly platform="linux_amd64"
+    readonly archive_sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+    ;;
+  *)
+    echo "Unsupported actionlint platform: $(uname -s)-$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+cleanup() {
+  rm -rf -- "${temporary_directory}"
+}
+trap cleanup EXIT
+
+curl \
+  --fail \
+  --location \
+  --proto '=https' \
+  --retry 3 \
+  --retry-all-errors \
+  --show-error \
+  --silent \
+  --tlsv1.2 \
+  --output "${archive}" \
+  "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/actionlint_${actionlint_version}_${platform}.tar.gz"
+
+if command -v sha256sum >/dev/null 2>&1 && [[ "$(uname -s)" != "Darwin" ]]; then
+  printf '%s  %s\n' "${archive_sha256}" "${archive}" | sha256sum --check
+else
+  printf '%s  %s\n' "${archive_sha256}" "${archive}" | shasum -a 256 --check
+fi
+tar -xzf "${archive}" -C "${temporary_directory}" actionlint
+"${temporary_directory}/actionlint" "$@"

--- a/scripts/release/publish-npm.mjs
+++ b/scripts/release/publish-npm.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export function calculateIntegrity(archivePath) {
+  return `sha512-${createHash("sha512").update(readFileSync(archivePath)).digest("base64")}`;
+}
+
+export function isNotFound(result) {
+  return (
+    result.status !== 0 && /\bE404\b|404 Not Found/i.test(`${result.stdout}\n${result.stderr}`)
+  );
+}
+
+export function parsePublishedIntegrity(result) {
+  if (result.status !== 0) {
+    if (isNotFound(result)) {
+      return undefined;
+    }
+    throw new Error(`npm view failed:\n${result.stderr || result.stdout}`);
+  }
+
+  const integrity = JSON.parse(result.stdout);
+  if (typeof integrity !== "string" || !integrity.startsWith("sha512-")) {
+    throw new Error("npm returned an invalid dist.integrity value");
+  }
+  return integrity;
+}
+
+function runNpm(args, stdio = "pipe") {
+  return spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", args, {
+    encoding: "utf8",
+    stdio,
+  });
+}
+
+function readPublishedIntegrity(specifier) {
+  return parsePublishedIntegrity(runNpm(["view", specifier, "dist.integrity", "--json"]));
+}
+
+async function main() {
+  const archivePath = process.argv[2];
+  if (!archivePath) {
+    throw new Error("Usage: publish-npm.mjs <package.tgz>");
+  }
+
+  const packageJson = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url)));
+  const specifier = `${packageJson.name}@${packageJson.version}`;
+  const expectedIntegrity = calculateIntegrity(archivePath);
+  const publishedIntegrity = readPublishedIntegrity(specifier);
+
+  if (publishedIntegrity !== undefined) {
+    if (publishedIntegrity !== expectedIntegrity) {
+      throw new Error(
+        `${specifier} already exists with integrity ${publishedIntegrity}, expected ${expectedIntegrity}`,
+      );
+    }
+    process.stdout.write(`${JSON.stringify({ package: specifier, state: "already-published" })}\n`);
+    return;
+  }
+
+  const publishResult = runNpm(
+    ["publish", archivePath, "--access", "public", "--provenance"],
+    "inherit",
+  );
+  if (publishResult.status !== 0) {
+    throw new Error(`npm publish failed with exit code ${publishResult.status}`);
+  }
+
+  // npm reads can lag briefly behind a successful publish.
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const verifiedIntegrity = readPublishedIntegrity(specifier);
+    if (verifiedIntegrity !== undefined) {
+      if (verifiedIntegrity !== expectedIntegrity) {
+        throw new Error(
+          `Published ${specifier} integrity ${verifiedIntegrity} does not match ${expectedIntegrity}`,
+        );
+      }
+      process.stdout.write(`${JSON.stringify({ package: specifier, state: "published" })}\n`);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Published ${specifier} was not readable after verification retries`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/release/publish-npm.mjs
+++ b/scripts/release/publish-npm.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";

--- a/scripts/release/publish-registry.mjs
+++ b/scripts/release/publish-registry.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";

--- a/scripts/release/publish-registry.mjs
+++ b/scripts/release/publish-registry.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const registryBaseUrl = "https://registry.modelcontextprotocol.io/v0.1/servers";
+const expected = JSON.parse(readFileSync(new URL("../../server.json", import.meta.url)));
+
+export function comparable(metadata) {
+  const server = metadata.server ?? metadata;
+  return {
+    name: server.name,
+    version: server.version,
+    packages: server.packages?.map((entry) => ({
+      registryType: entry.registryType,
+      identifier: entry.identifier,
+      version: entry.version,
+    })),
+  };
+}
+
+export function assertMatching(metadata, expectedMetadata = expected) {
+  if (JSON.stringify(comparable(metadata)) !== JSON.stringify(comparable(expectedMetadata))) {
+    throw new Error("The existing MCP Registry version does not match server.json");
+  }
+}
+
+async function readPublishedVersion() {
+  const url = `${registryBaseUrl}/${encodeURIComponent(expected.name)}/versions/${encodeURIComponent(expected.version)}`;
+  const response = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+  if (response.status === 404) {
+    return undefined;
+  }
+  if (!response.ok) {
+    throw new Error(`MCP Registry lookup failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  const existing = await readPublishedVersion();
+  if (existing) {
+    assertMatching(existing);
+    process.stdout.write(
+      `${JSON.stringify({ server: expected.name, version: expected.version, state: "already-published" })}\n`,
+    );
+    return;
+  }
+
+  execFileSync("mcp-publisher", ["login", "github-oidc"], { stdio: "inherit" });
+  execFileSync("mcp-publisher", ["publish"], { stdio: "inherit" });
+
+  // Registry reads may lag briefly behind a successful write.
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const published = await readPublishedVersion();
+    if (published) {
+      assertMatching(published);
+      process.stdout.write(
+        `${JSON.stringify({ server: expected.name, version: expected.version, state: "published" })}\n`,
+      );
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error("MCP Registry did not expose the published version after verification retries");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
 const TransportSchema = z.enum(["stdio", "http"]);
+const CommaSeparatedHostnamesSchema = z
+  .string()
+  .refine(
+    (value) => value.split(",").every((hostname) => hostname.trim().length > 0),
+    "MCP_HTTP_ALLOWED_HOSTS must be a comma-separated list of non-empty hostnames",
+  )
+  .transform((value) => value.split(",").map((hostname) => hostname.trim()));
 
 const EnvSchema = z.object({
   SWITCHBOT_TOKEN: z.string().min(1, "SWITCHBOT_TOKEN is required"),
@@ -10,6 +17,7 @@ const EnvSchema = z.object({
   MCP_SERVER_API_KEY: z.string().optional(),
   MCP_HTTP_HOST: z.string().default("127.0.0.1"),
   MCP_HTTP_PORT: z.coerce.number().int().min(1).max(65535).default(8787),
+  MCP_HTTP_ALLOWED_HOSTS: CommaSeparatedHostnamesSchema.optional(),
   MCP_HTTP_PATH: z
     .string()
     .default("/mcp")
@@ -35,6 +43,7 @@ export interface AppConfig {
       port: number;
       path: string;
       apiKey?: string;
+      allowedHosts: string[];
     };
   };
   cache: {
@@ -75,6 +84,10 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
         port: value.MCP_HTTP_PORT,
         path: value.MCP_HTTP_PATH,
         apiKey: value.MCP_SERVER_API_KEY,
+        allowedHosts: buildAllowedHostnames(
+          value.MCP_HTTP_HOST,
+          value.MCP_HTTP_ALLOWED_HOSTS ?? [],
+        ),
       },
     },
     cache: {
@@ -82,4 +95,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     },
     logLevel: value.LOG_LEVEL,
   };
+}
+
+function buildAllowedHostnames(host: string, configured: string[]): string[] {
+  const normalizedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return [...new Set([normalizedHost, "localhost", "127.0.0.1", "[::1]", ...configured])];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ async function main(): Promise<void> {
       port: config.transport.http.port,
       path: config.transport.http.path,
       apiKey: config.transport.http.apiKey,
+      allowedHosts: config.transport.http.allowedHosts,
       logger,
     });
     return;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,7 @@ const rank: Record<LogLevel, number> = {
   warn: 30,
   error: 40,
 };
+const SENSITIVE_LOG_KEY = /authorization|api[-_]?key|secret|token/i;
 
 export interface Logger {
   debug(message: string, meta?: unknown): void;
@@ -19,9 +20,8 @@ export function createLogger(level: LogLevel): Logger {
     if (rank[target] < rank[level]) {
       return;
     }
-    const payload = meta === undefined ? "" : ` ${JSON.stringify(meta)}`;
     // eslint-disable-next-line no-console
-    console.error(`[${target.toUpperCase()}] ${message}${payload}`);
+    console.error(serializeLogEntry(target, message, meta));
   };
 
   return {
@@ -30,4 +30,26 @@ export function createLogger(level: LogLevel): Logger {
     warn: (message, meta) => log("warn", message, meta),
     error: (message, meta) => log("error", message, meta),
   };
+}
+
+function serializeLogEntry(level: LogLevel, message: string, meta?: unknown): string {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...(meta === undefined ? {} : { meta }),
+  };
+
+  try {
+    return JSON.stringify(entry, (key, value) =>
+      SENSITIVE_LOG_KEY.test(key) ? "[REDACTED]" : value,
+    );
+  } catch {
+    return JSON.stringify({
+      timestamp: entry.timestamp,
+      level,
+      message,
+      meta: "[unserializable]",
+    });
+  }
 }

--- a/src/mcp/result.ts
+++ b/src/mcp/result.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/server";
 
 export function successResult<T extends Record<string, unknown>>(
   summary: string,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/server";
 import packageJson from "../../package.json" with { type: "json" };
 
 import type { TtlCache } from "../cache/ttl-cache.js";
@@ -20,6 +20,9 @@ export function createSwitchBotMcpServer(options: CreateServerOptions): McpServe
       version: packageJson.version,
     },
     {
+      // SDK v2 keeps modern negotiation opt-in so established 2025 clients can
+      // continue using initialize while modern clients discover 2026 explicitly.
+      supportedProtocolVersions: ["2026-07-28", ...SUPPORTED_PROTOCOL_VERSIONS],
       capabilities: {
         tools: {},
       },

--- a/src/mcp/tools/register-tools.ts
+++ b/src/mcp/tools/register-tools.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 
 import { TtlCache } from "../../cache/ttl-cache.js";
@@ -7,6 +7,24 @@ import { errorResult, successResult } from "../result.js";
 
 const DEVICE_LIST_CACHE_KEY = "devices";
 const SCENE_LIST_CACHE_KEY = "scenes";
+const READ_ONLY_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+} as const;
+const IDEMPOTENT_MUTATION_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: true,
+} as const;
+const NON_IDEMPOTENT_MUTATION_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: true,
+} as const;
 
 const listDevicesOutputSchema = z.object({
   devices: z.array(
@@ -79,6 +97,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_list_devices",
     {
       description: "List SwitchBot devices",
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       inputSchema: {
         includeInfrared: z.boolean().optional(),
         nameQuery: z.string().optional(),
@@ -114,6 +133,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_list_devices_raw",
     {
       description: "List SwitchBot devices with raw upstream fields (advanced/unstable)",
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       inputSchema: {
         includeInfrared: z.boolean().optional(),
         nameQuery: z.string().optional(),
@@ -150,6 +170,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_get_device_status",
     {
       description: "Get status for a specific SwitchBot device",
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       inputSchema: {
         deviceId: z.string().min(1),
       },
@@ -174,6 +195,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_set_power",
     {
       description: "Turn a SwitchBot device on or off",
+      annotations: IDEMPOTENT_MUTATION_ANNOTATIONS,
       inputSchema: {
         deviceId: z.string().min(1),
         power: z.enum(["on", "off"]),
@@ -197,6 +219,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_send_command",
     {
       description: "Send a raw command to a SwitchBot device",
+      annotations: NON_IDEMPOTENT_MUTATION_ANNOTATIONS,
       inputSchema: {
         deviceId: z.string().min(1),
         command: z.string().min(1),
@@ -234,6 +257,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_list_scenes",
     {
       description: "List manual scenes in SwitchBot",
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       inputSchema: {},
       outputSchema: listScenesOutputSchema,
     },
@@ -260,6 +284,7 @@ export function registerTools(options: ToolRegistrationOptions): void {
     "switchbot_execute_scene",
     {
       description: "Execute a manual SwitchBot scene",
+      annotations: NON_IDEMPOTENT_MUTATION_ANNOTATIONS,
       inputSchema: {
         sceneId: z.string().min(1),
       },

--- a/src/switchbot/client.ts
+++ b/src/switchbot/client.ts
@@ -42,6 +42,9 @@ const apiEnvelopeSchema = z.object({
 });
 
 const unknownRecordSchema = z.record(z.string(), z.unknown());
+const RETRYABLE_READ_STATUSES = new Set([429, 502, 503, 504]);
+const MAX_READ_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 100;
 
 interface SwitchBotClientOptions {
   token: string;
@@ -123,33 +126,64 @@ export class SwitchBotClient {
     bodySchema: z.ZodType<T>,
   ): Promise<T> {
     try {
-      const authHeaders = createSwitchBotAuthHeaders({
-        token: this.options.token,
-        secret: this.options.secret,
-      });
-      const response = await fetch(`${this.baseURL}${path}`, {
-        ...init,
-        headers: {
-          Authorization: authHeaders.Authorization,
-          sign: authHeaders.sign,
-          nonce: authHeaders.nonce,
-          t: authHeaders.t,
-          "Content-Type": "application/json; charset=utf-8",
-        },
-        signal: AbortSignal.timeout(this.options.timeoutMs),
-        // SwitchBot credentials are scoped to one origin and must never follow a redirect.
-        redirect: "error",
-      });
-      const rawBody = await readJsonBody(response);
+      const deadline = Date.now() + this.options.timeoutMs;
+      let retries = 0;
 
-      if (!response.ok) {
+      while (true) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw timeoutError();
+        }
+
+        const authHeaders = createSwitchBotAuthHeaders({
+          token: this.options.token,
+          secret: this.options.secret,
+        });
+        const response = await fetch(`${this.baseURL}${path}`, {
+          ...init,
+          headers: {
+            Authorization: authHeaders.Authorization,
+            sign: authHeaders.sign,
+            nonce: authHeaders.nonce,
+            t: authHeaders.t,
+            "Content-Type": "application/json; charset=utf-8",
+          },
+          signal: AbortSignal.timeout(remainingMs),
+          // SwitchBot credentials are scoped to one origin and must never follow a redirect.
+          redirect: "error",
+        });
+        const rawBody = await readJsonBody(response);
+
+        if (response.ok) {
+          return this.unwrap(path, rawBody, bodySchema);
+        }
+
+        if (
+          init.method === "GET" &&
+          RETRYABLE_READ_STATUSES.has(response.status) &&
+          retries < MAX_READ_RETRIES
+        ) {
+          const retryDelayMs = getRetryDelayMs(response, retries);
+          if (retryDelayMs >= deadline - Date.now()) {
+            throw timeoutError();
+          }
+
+          retries += 1;
+          this.options.logger.warn("Retrying read-only SwitchBot API request", {
+            path,
+            statusCode: response.status,
+            retry: retries,
+            retryDelayMs,
+          });
+          await sleep(retryDelayMs);
+          continue;
+        }
+
         throw new SwitchBotHttpError(
           extractMessage(rawBody) ?? `HTTP ${response.status}`,
           response.status,
         );
       }
-
-      return this.unwrap(path, rawBody, bodySchema);
     } catch (error) {
       throw normalizeSwitchBotError(error);
     }
@@ -179,6 +213,32 @@ export class SwitchBotClient {
     });
     return body.data;
   }
+}
+
+function getRetryDelayMs(response: Response, retryIndex: number): number {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return seconds * 1_000;
+    }
+
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt)) {
+      return Math.max(0, retryAt - Date.now());
+    }
+  }
+
+  const exponentialDelay = RETRY_BASE_DELAY_MS * 2 ** retryIndex;
+  return exponentialDelay + Math.floor(Math.random() * RETRY_BASE_DELAY_MS);
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function timeoutError(): SwitchBotHttpError {
+  return new SwitchBotHttpError("SwitchBot API request timed out", undefined, "ETIMEDOUT");
 }
 
 async function readJsonBody(response: Response): Promise<unknown> {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -3,7 +3,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { timingSafeEqual } from "node:crypto";
 import { URL } from "node:url";
 
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  hostHeaderValidation,
+  NodeStreamableHTTPServerTransport,
+  originValidation,
+} from "@modelcontextprotocol/node";
 
 import type { Logger } from "../logger.js";
 import { createSwitchBotMcpServer } from "../mcp/server.js";
@@ -13,6 +17,7 @@ export interface HttpServerOptions {
   port: number;
   path: string;
   apiKey: string;
+  allowedHosts: string[];
   logger: Logger;
 }
 
@@ -20,21 +25,23 @@ export async function startHttpServer(
   mcpServer: ReturnType<typeof createSwitchBotMcpServer>,
   options: HttpServerOptions,
 ): Promise<void> {
-  const transport = new StreamableHTTPServerTransport({
+  const transport = new NodeStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
   });
   await mcpServer.connect(transport);
+  const validateHost = hostHeaderValidation(options.allowedHosts);
+  // Origin validation is a protocol requirement; non-browser clients without Origin still pass.
+  const validateOrigin = originValidation(options.allowedHosts);
 
   const server = createServer(async (req, res) => {
     try {
-      if (!requestPathMatches(req, options.path)) {
-        respondJson(res, 404, { error: "Not Found" });
+      if (!validateHost(req, res) || !validateOrigin(req, res)) {
         return;
       }
 
-      if (!isAllowedHost(req, options.host)) {
-        respondJson(res, 403, { error: "Forbidden host header" });
+      if (!requestPathMatches(req, options.path)) {
+        respondJson(res, 404, { error: "Not Found" });
         return;
       }
 
@@ -103,34 +110,6 @@ export function isAuthorized(req: IncomingMessage, apiKey: string): boolean {
   const actual = Buffer.from(auth.slice(prefix.length));
   const expected = Buffer.from(apiKey);
   return actual.length === expected.length && timingSafeEqual(actual, expected);
-}
-
-export function isAllowedHost(req: IncomingMessage, host: string): boolean {
-  const header = req.headers.host;
-  if (!header) {
-    return false;
-  }
-
-  let parsedHeader: URL;
-  try {
-    parsedHeader = new URL(`http://${header}`);
-  } catch {
-    return false;
-  }
-
-  const hostOnly = parsedHeader.hostname;
-  const allowed = new Set<string>();
-  allowed.add(host);
-  allowed.add("localhost");
-  allowed.add("127.0.0.1");
-  allowed.add("[::1]");
-
-  if (host === "0.0.0.0") {
-    allowed.add("0.0.0.0");
-  }
-
-  // Port mappings and reverse proxies legitimately change the public port.
-  return allowed.has(hostOnly);
 }
 
 export function respondJson(res: ServerResponse, statusCode: number, body: unknown): void {

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,4 +1,4 @@
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 
 import type { Logger } from "../logger.js";
 import { createSwitchBotMcpServer } from "../mcp/server.js";
@@ -7,7 +7,10 @@ export async function startStdioServer(
   mcpServer: ReturnType<typeof createSwitchBotMcpServer>,
   logger: Logger,
 ): Promise<void> {
-  const transport = new StdioServerTransport();
-  await mcpServer.connect(transport);
+  // The v2 entrypoint classifies the opening exchange before pinning this
+  // server instance, which is required for 2026 discovery and legacy initialize.
+  serveStdio(() => mcpServer, {
+    onerror: (error) => logger.error("stdio transport failed", { error: error.message }),
+  });
   logger.info("SwitchBot MCP server running on stdio");
 }

--- a/tests/config/env.test.ts
+++ b/tests/config/env.test.ts
@@ -1,3 +1,4 @@
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import { loadConfig } from "../../src/config/env.js";
@@ -16,6 +17,7 @@ describe("loadConfig", () => {
           host: "127.0.0.1",
           port: 8787,
           path: "/mcp",
+          allowedHosts: ["127.0.0.1", "localhost", "[::1]"],
         },
       },
       switchbot: {
@@ -36,5 +38,60 @@ describe("loadConfig", () => {
         MCP_TRANSPORT: "http",
       }),
     ).toThrow("MCP_SERVER_API_KEY is required when MCP_TRANSPORT=http");
+  });
+
+  it("adds explicitly allowed HTTP hostnames without removing secure local defaults", () => {
+    const config = loadConfig({
+      SWITCHBOT_TOKEN: "token",
+      SWITCHBOT_SECRET: "secret",
+      MCP_TRANSPORT: "http",
+      MCP_SERVER_API_KEY: "api-key",
+      MCP_HTTP_HOST: "0.0.0.0",
+      MCP_HTTP_ALLOWED_HOSTS: "switchbot.example.test, proxy.localhost",
+    });
+
+    expect(config.transport.http.allowedHosts).toEqual([
+      "0.0.0.0",
+      "localhost",
+      "127.0.0.1",
+      "[::1]",
+      "switchbot.example.test",
+      "proxy.localhost",
+    ]);
+  });
+
+  it("rejects an empty entry in the HTTP hostname allowlist", () => {
+    expect(() =>
+      loadConfig({
+        SWITCHBOT_TOKEN: "token",
+        SWITCHBOT_SECRET: "secret",
+        MCP_TRANSPORT: "http",
+        MCP_SERVER_API_KEY: "api-key",
+        MCP_HTTP_ALLOWED_HOSTS: "switchbot.example.test,,proxy.localhost",
+      }),
+    ).toThrow("MCP_HTTP_ALLOWED_HOSTS");
+  });
+
+  it("preserves every configured hostname exactly once for varied valid lists", () => {
+    const hostname = fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/).map((label) => `${label}.test`);
+
+    fc.assert(
+      fc.property(fc.array(hostname, { minLength: 1, maxLength: 30 }), (hostnames) => {
+        const config = loadConfig({
+          SWITCHBOT_TOKEN: "token",
+          SWITCHBOT_SECRET: "secret",
+          MCP_TRANSPORT: "http",
+          MCP_SERVER_API_KEY: "api-key",
+          MCP_HTTP_ALLOWED_HOSTS: hostnames.map((value) => ` ${value} `).join(","),
+        });
+
+        const allowedHosts = config.transport.http.allowedHosts;
+        expect(new Set(allowedHosts).size).toBe(allowedHosts.length);
+        for (const configured of new Set(hostnames)) {
+          expect(allowedHosts).toContain(configured);
+        }
+      }),
+      { numRuns: 200 },
+    );
   });
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -16,7 +16,13 @@ describe("createLogger", () => {
     logger.warn("warning", { deviceId: "device-1" });
 
     expect(error).toHaveBeenCalledTimes(1);
-    expect(error).toHaveBeenCalledWith('[WARN] warning {"deviceId":"device-1"}');
+    const entry = JSON.parse(String(error.mock.calls[0]?.[0]));
+    expect(entry).toMatchObject({
+      level: "warn",
+      message: "warning",
+      meta: { deviceId: "device-1" },
+    });
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it("logs every supported level at debug", () => {
@@ -29,5 +35,30 @@ describe("createLogger", () => {
     logger.error("error");
 
     expect(error).toHaveBeenCalledTimes(4);
+  });
+
+  it("redacts sensitive structured metadata", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logger = createLogger("info");
+
+    logger.info("configured", {
+      token: "token-value",
+      nested: { apiKey: "key-value", safe: "visible" },
+    });
+
+    expect(JSON.parse(String(error.mock.calls[0]?.[0])).meta).toEqual({
+      token: "[REDACTED]",
+      nested: { apiKey: "[REDACTED]", safe: "visible" },
+    });
+  });
+
+  it("does not throw when metadata cannot be serialized", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logger = createLogger("info");
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => logger.info("circular", circular)).not.toThrow();
+    expect(JSON.parse(String(error.mock.calls[0]?.[0])).meta).toBe("[unserializable]");
   });
 });

--- a/tests/mcp/contract.test.ts
+++ b/tests/mcp/contract.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
 
 import { TtlCache } from "../../src/cache/ttl-cache.js";
 import { createLogger } from "../../src/logger.js";
@@ -76,6 +75,31 @@ describe("MCP tools contract", () => {
       "switchbot_send_command",
       "switchbot_set_power",
     ]);
+  });
+
+  it("describes read and mutation risk to MCP clients", async () => {
+    const tools = await client.listTools();
+    const byName = new Map(tools.tools.map((tool) => [tool.name, tool.annotations]));
+
+    expect(byName.get("switchbot_list_devices")).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+    expect(byName.get("switchbot_set_power")).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+    expect(byName.get("switchbot_send_command")).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+    expect(byName.get("switchbot_execute_scene")).toEqual(byName.get("switchbot_send_command"));
   });
 
   it("returns structured content from tool calls", async () => {

--- a/tests/mcp/stdio-e2e.test.ts
+++ b/tests/mcp/stdio-e2e.test.ts
@@ -2,8 +2,8 @@ import { createServer } from "node:http";
 import { AddressInfo } from "node:net";
 import { createRequire } from "node:module";
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -46,7 +46,10 @@ describe("stdio e2e", () => {
       stderr: "pipe",
     });
 
-    client = new Client({ name: "e2e-client", version: "1.0.0" });
+    client = new Client(
+      { name: "e2e-client", version: "1.0.0" },
+      { versionNegotiation: { mode: { pin: "2026-07-28" } } },
+    );
     await client.connect(transport);
   });
 
@@ -57,6 +60,8 @@ describe("stdio e2e", () => {
   });
 
   it("executes all v3 tools through stdio process and enforces cache behavior", async () => {
+    expect(client.getProtocolEra()).toBe("modern");
+
     const listedTools = await client.listTools();
     const names = listedTools.tools.map((t) => t.name).sort();
 

--- a/tests/scripts/publish-npm.test.mjs
+++ b/tests/scripts/publish-npm.test.mjs
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  calculateIntegrity,
+  isNotFound,
+  parsePublishedIntegrity,
+} from "../../scripts/release/publish-npm.mjs";
+import { assertMatching } from "../../scripts/release/publish-registry.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("resumable npm publication", () => {
+  it("calculates the registry integrity from the exact archive bytes", () => {
+    const directory = mkdtempSync(join(tmpdir(), "switchbot-mcp-integrity-"));
+    temporaryDirectories.push(directory);
+    const archive = join(directory, "package.tgz");
+    writeFileSync(archive, "deterministic package bytes");
+
+    const expected = `sha512-${createHash("sha512")
+      .update("deterministic package bytes")
+      .digest("base64")}`;
+    expect(calculateIntegrity(archive)).toBe(expected);
+  });
+
+  it("treats only npm not-found responses as an unpublished version", () => {
+    const notFound = { status: 1, stdout: "", stderr: "npm error code E404" };
+    const outage = { status: 1, stdout: "", stderr: "npm error code E500" };
+
+    expect(isNotFound(notFound)).toBe(true);
+    expect(parsePublishedIntegrity(notFound)).toBeUndefined();
+    expect(isNotFound(outage)).toBe(false);
+    expect(() => parsePublishedIntegrity(outage)).toThrow("npm view failed");
+  });
+
+  it("rejects malformed registry integrity instead of assuming success", () => {
+    expect(() =>
+      parsePublishedIntegrity({ status: 0, stdout: '"sha256-invalid"', stderr: "" }),
+    ).toThrow("invalid dist.integrity");
+  });
+});
+
+describe("resumable MCP Registry publication", () => {
+  const expected = {
+    name: "io.github.example/switchbot",
+    version: "3.0.0",
+    packages: [
+      {
+        registryType: "npm",
+        identifier: "@example/switchbot",
+        version: "3.0.0",
+      },
+    ],
+  };
+
+  it("accepts an existing immutable version with matching package identity", () => {
+    expect(() =>
+      assertMatching(
+        {
+          server: expected,
+          _meta: { "io.modelcontextprotocol.registry/official": { status: "active" } },
+        },
+        expected,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a version whose package identity differs", () => {
+    const mismatched = structuredClone(expected);
+    mismatched.packages[0].version = "2.9.0";
+
+    expect(() => assertMatching({ server: mismatched }, expected)).toThrow(
+      "does not match server.json",
+    );
+  });
+});

--- a/tests/switchbot/client.test.ts
+++ b/tests/switchbot/client.test.ts
@@ -86,6 +86,56 @@ describe("SwitchBotClient", () => {
     );
   });
 
+  it("retries transient read failures within the request deadline", async () => {
+    let attempts = 0;
+    const baseURL = await startMockSwitchBotServer((_req, res) => {
+      attempts += 1;
+      if (attempts === 1) {
+        res.setHeader("Retry-After", "0");
+        respondJson(res, 503, { message: "temporarily unavailable" });
+        return;
+      }
+
+      respondJson(res, 200, {
+        statusCode: 100,
+        message: "success",
+        body: [{ sceneId: "S1", sceneName: "Scene" }],
+      });
+    });
+
+    await expect(createClient(baseURL).listScenes()).resolves.toHaveLength(1);
+    expect(attempts).toBe(2);
+  });
+
+  it("stops after the bounded number of read retries", async () => {
+    let attempts = 0;
+    const baseURL = await startMockSwitchBotServer((_req, res) => {
+      attempts += 1;
+      res.setHeader("Retry-After", "0");
+      respondJson(res, 503, { message: "temporarily unavailable" });
+    });
+
+    await expect(createClient(baseURL).listScenes()).rejects.toMatchObject({
+      name: "SwitchBotHttpError",
+      status: 503,
+    });
+    expect(attempts).toBe(3);
+  });
+
+  it("never retries mutating commands after an upstream failure", async () => {
+    let attempts = 0;
+    const baseURL = await startMockSwitchBotServer((_req, res) => {
+      attempts += 1;
+      res.setHeader("Retry-After", "0");
+      respondJson(res, 503, { message: "temporarily unavailable" });
+    });
+
+    await expect(
+      createClient(baseURL).sendCommand({ deviceId: "A", command: "turnOn" }),
+    ).rejects.toBeInstanceOf(SwitchBotHttpError);
+    expect(attempts).toBe(1);
+  });
+
   it("normalizes timeout errors", async () => {
     const baseURL = await startMockSwitchBotServer((_req, res) => {
       setTimeout(() => {

--- a/tests/transports/http-e2e.test.ts
+++ b/tests/transports/http-e2e.test.ts
@@ -41,6 +41,7 @@ describe("http e2e", () => {
         MCP_HTTP_HOST: "127.0.0.1",
         MCP_HTTP_PORT: String(mcpPort),
         MCP_HTTP_PATH: MCP_PATH,
+        MCP_HTTP_ALLOWED_HOSTS: "switchbot.example.test",
         LOG_LEVEL: "error",
       }),
       stdio: ["ignore", "pipe", "pipe"],
@@ -81,6 +82,33 @@ describe("http e2e", () => {
     });
 
     expect(response.statusCode).toBe(403);
+  });
+
+  it("returns 403 for an untrusted browser origin", async () => {
+    const response = await postRaw({
+      path: MCP_PATH,
+      port: mcpPort,
+      headers: {
+        authorization: `Bearer ${API_KEY}`,
+        origin: "https://evil.example.test",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("accepts an explicitly allowed host and same-host origin", async () => {
+    const response = await postRaw({
+      path: MCP_PATH,
+      port: mcpPort,
+      headers: {
+        authorization: `Bearer ${API_KEY}`,
+        host: "switchbot.example.test:443",
+        origin: "https://switchbot.example.test",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
   });
 
   it("returns 404 for invalid path", async () => {

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isAllowedHost, isAuthorized, requestPathMatches } from "../../src/transports/http.js";
+import { isAuthorized, requestPathMatches } from "../../src/transports/http.js";
 
 function req(input: { host?: string; authorization?: string; url?: string }) {
   return {
@@ -21,13 +21,5 @@ describe("HTTP transport guards", () => {
   it("validates bearer auth", () => {
     expect(isAuthorized(req({ authorization: "Bearer abc" }), "abc")).toBe(true);
     expect(isAuthorized(req({ authorization: "Bearer def" }), "abc")).toBe(false);
-  });
-
-  it("validates host header against localhost constraints", () => {
-    expect(isAllowedHost(req({ host: "127.0.0.1:8787" }), "127.0.0.1")).toBe(true);
-    expect(isAllowedHost(req({ host: "localhost:18787" }), "127.0.0.1")).toBe(true);
-    expect(isAllowedHost(req({ host: "evil.example:8787" }), "127.0.0.1")).toBe(false);
-    expect(isAllowedHost(req({ host: "[::1]:8787" }), "::1")).toBe(true);
-    expect(isAllowedHost(req({ host: "not a host" }), "127.0.0.1")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- migrate from the monolithic MCP SDK v1 package to SDK v2 packages and exercise explicit MCP 2026-07-28 negotiation through the real stdio process
- validate HTTP Host and browser Origin headers, annotate tool risk, add bounded read-only retries, and emit redacted JSONL logs
- make tag-based releases least-privilege and resumable across npm, MCP Registry, and GitHub Release publication
- pin downloaded CI tools and the Docker base image, minimize the Docker context, add Docker Dependabot coverage, and retain machine-readable failure evidence briefly
- add property-based configuration coverage and document the new security and release contracts

## Verification

- `npm run check:ci` (56 passed, 1 credential-gated live test skipped)
- `npm run test:coverage` (91.6% statements, 76.71% branches, 96.87% functions, 91.5% lines)
- `npm run smoke:container` (missing config exit 1, unauthorized 401, authorized 200, runtime user node)
- `npm run lint:actions`
- `npm audit --audit-level=moderate --json` (0 vulnerabilities)
- packed artifact installation and fail-closed execution via `npm run smoke:package`

## Release note

No npm or MCP Registry publication is performed by this PR. The source workflow now expects a protected `release` environment and matching npm trusted-publisher configuration before the version tag is pushed. Official Registry publication remains tracked in #7.

Refs #7