### PR TITLE
fix(deps): keep container on LTS Node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,11 @@ updates:
       day: monday
       time: "04:45"
       timezone: Asia/Tokyo
+    ignore:
+      # The production image follows the documented LTS runtime, not odd-numbered releases.
+      - dependency-name: node
+        versions:
+          - "25.x"
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
## Summary

- prevent Dependabot from proposing the unsupported Node 25 container line
- keep the production image aligned with the documented Node 24 LTS runtime
- retain future review of supported even-numbered runtime upgrades

## Validation

- parsed `.github/dependabot.yml` and asserted the Docker ignore policy
- `git diff --check`
- commit-msg and pre-push hooks passed

Supersedes #12.